### PR TITLE
[Feat] Home 뷰 좋아요 API 연동

### DIFF
--- a/Runday/Runday.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Runday/Runday.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Alamofire/Alamofire.git",
       "state" : {
-        "revision" : "f512df48300140994b1ea56a2ff024a4734cef2b",
-        "version" : "5.6.3"
+        "revision" : "8dd85aee02e39dd280c75eef88ffdb86eed4b07b",
+        "version" : "5.6.2"
       }
     },
     {

--- a/Runday/Runday/Screen/Home/Controllers/TimeExerciseViewController.swift
+++ b/Runday/Runday/Screen/Home/Controllers/TimeExerciseViewController.swift
@@ -84,7 +84,6 @@ class TimeExerciseViewController: UIViewController {
             self.timeExerciseCollectionView.reloadData()
         }
     }
-
 }
 
 // MARK: - UICollectionViewDataSource

--- a/Runday/Runday/Screen/Home/Controllers/TimeExerciseViewController.swift
+++ b/Runday/Runday/Screen/Home/Controllers/TimeExerciseViewController.swift
@@ -128,3 +128,17 @@ extension TimeExerciseViewController: UICollectionViewDelegateFlowLayout {
         return Exercise.exerciseInset
     }
 }
+
+// MARK: - Network
+
+extension TimeExerciseViewController {
+    func like() {
+        LikeAPI.shared.putLike(for: CommonRequestDTO(runId: 1)) { data in
+        }
+    }
+    
+    func disLike() {
+        LikeAPI.shared.putDislike(for: CommonRequestDTO(runId: 1)) { data in
+        }
+    }
+}

--- a/Runday/Runday/Screen/Home/View/Reusable/ExerciseCollectionViewCell.swift
+++ b/Runday/Runday/Screen/Home/View/Reusable/ExerciseCollectionViewCell.swift
@@ -45,8 +45,8 @@ class ExerciseCollectionViewCell: UICollectionViewCell {
     }
     
     private lazy var likeButton = UIButton().then {
-        $0.setImage(UIImage(named: "heart")?.withRenderingMode(.alwaysOriginal), for: .disabled)
-        $0.setImage(UIImage(named: "heart.fill")?.withRenderingMode(.alwaysOriginal), for: .normal)
+        $0.setImage(UIImage(named: "heart")?.withRenderingMode(.alwaysOriginal), for: .normal)
+        $0.setImage(UIImage(named: "heart.fill")?.withRenderingMode(.alwaysOriginal), for: .selected)
         $0.addTarget(self, action: #selector(heartButtonDidTap), for: .touchUpInside)
     }
     
@@ -54,7 +54,6 @@ class ExerciseCollectionViewCell: UICollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        
         setUI()
         setLayout()
     }
@@ -126,7 +125,7 @@ class ExerciseCollectionViewCell: UICollectionViewCell {
         titleLabel.text = runModel.title
         routineLabel.text = runModel.routine
         stageLabel.text = runModel.stage
-        likeButton.isEnabled = runModel.isLiked
+        likeButton.isSelected = runModel.isLiked
         
         guard let highlight = runModel.highlight else {return}
         titleLabel.attributedText = changeTextColor(text: runModel.title, highlight: highlight)
@@ -142,13 +141,14 @@ class ExerciseCollectionViewCell: UICollectionViewCell {
     }
     
     @objc
-    private func heartButtonDidTap() {
-        likeButton.isSelected.toggle()
+    func heartButtonDidTap() {
+        let timeExerciseViewController = TimeExerciseViewController()
         if likeButton.isSelected {
-            likeButton.isSelected = false
+            timeExerciseViewController.disLike()
         } else {
-            likeButton.isSelected = true
+            timeExerciseViewController.like()
         }
+        likeButton.isSelected.toggle()
     }
     
     func changeTextColor(text: String, highlight: String) -> NSAttributedString {

--- a/Runday/Runday/Screen/Home/View/Reusable/ExerciseCollectionViewCell.swift
+++ b/Runday/Runday/Screen/Home/View/Reusable/ExerciseCollectionViewCell.swift
@@ -45,8 +45,8 @@ class ExerciseCollectionViewCell: UICollectionViewCell {
     }
     
     private lazy var likeButton = UIButton().then {
-        $0.setImage(UIImage(named: "heart"), for: .normal)
-        $0.setImage(UIImage(named: "heart.fill"), for: .selected)
+        $0.setImage(UIImage(named: "heart")?.withRenderingMode(.alwaysOriginal), for: .disabled)
+        $0.setImage(UIImage(named: "heart.fill")?.withRenderingMode(.alwaysOriginal), for: .normal)
         $0.addTarget(self, action: #selector(heartButtonDidTap), for: .touchUpInside)
     }
     
@@ -126,6 +126,7 @@ class ExerciseCollectionViewCell: UICollectionViewCell {
         titleLabel.text = runModel.title
         routineLabel.text = runModel.routine
         stageLabel.text = runModel.stage
+        likeButton.isEnabled = runModel.isLiked
         
         guard let highlight = runModel.highlight else {return}
         titleLabel.attributedText = changeTextColor(text: runModel.title, highlight: highlight)
@@ -142,6 +143,7 @@ class ExerciseCollectionViewCell: UICollectionViewCell {
     
     @objc
     private func heartButtonDidTap() {
+        likeButton.isSelected.toggle()
         if likeButton.isSelected {
             likeButton.isSelected = false
         } else {


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
#26 

### ✅ 작업한 내용
- 서버 isLiked 값에 따라 Home 뷰의 하트 버튼 empty / filled 변경
- Home 뷰에 있는 하트 버튼 클릭 시 서버의 isLiked 값 true / false 변경

### ❗️PR Point
TimeExerciseViewController 에 API 받아오는 함수를 public 으로 만들어서
ExerciseCollectionViewCell 의 `heartButtonDidTap()` 함수에서 실행시켜줬습니다.

처음에 어떤 식으로 값을 받아와서 변경시켜줄지를 몰라서 `notificationcenter.default.addobserver` 이용해서 시도해보고 헤매다가
민이가 작성해 준 DataBind 함수 부분에서 값을 연동시켜줘야한다는 걸 깨달아서.. 잘 해결해냈습니다! 👍
Moya... 이젠 좀 친해졌을지도..? 🫠


### 📸 스크린샷
![Simulator Screen Recording - iPhone 12 - 2022-11-25 at 18 04 54](https://user-images.githubusercontent.com/70744494/203942360-6b26792e-70a2-41e9-a393-f0c8ba33d7f7.gif)


closed #26 

